### PR TITLE
fix: incorrect start command

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Now sudo is great, just like Safari — with your fingerprint in Terminal or wha
 
 ```powershell
 brew install artginzburg/tap/sudo-touchid
-sudo brew services start sudo-touchid
+sudo brew services restart artginzburg/tap/sudo-touchid
 ```
 
 > Check out [the formula](https://github.com/artginzburg/homebrew-tap/blob/main/Formula/sudo-touchid.rb) if you're interested


### PR DESCRIPTION
This PR fixes incorrect command in README

```bash
neo@neos-MacBook-Pro ~ % sudo brew services start sudo-touchid  
Error: Formula `sudo-touchid` is not installed.
```

Correct usage is 
```bash
sudo brew services restart artginzburg/tap/sudo-touchid
```