### PR TITLE
Harden install.sh file ownership and permissions

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,1 +1,24 @@
-curl -# https://raw.githubusercontent.com/artginzburg/sudo-touchid/main/sudo-touchid.sh -o /usr/local/bin/sudo-touchid && chmod +x /usr/local/bin/sudo-touchid && sudo curl -# https://raw.githubusercontent.com/artginzburg/sudo-touchid/main/com.user.sudo-touchid.plist -o /Library/LaunchDaemons/com.user.sudo-touchid.plist && /usr/local/bin/sudo-touchid
+#!/bin/sh
+set -e
+
+script_url="https://raw.githubusercontent.com/artginzburg/sudo-touchid/main/sudo-touchid.sh"
+plist_url="https://raw.githubusercontent.com/artginzburg/sudo-touchid/main/com.user.sudo-touchid.plist"
+bin_path="/usr/local/bin/sudo-touchid"
+plist_path="/Library/LaunchDaemons/com.user.sudo-touchid.plist"
+
+script_tmp="$(mktemp "${TMPDIR:-/tmp}/sudo-touchid.XXXXXX")"
+plist_tmp="$(mktemp "${TMPDIR:-/tmp}/sudo-touchid.plist.XXXXXX")"
+
+cleanup() {
+  rm -f "$script_tmp" "$plist_tmp"
+}
+trap cleanup EXIT INT TERM
+
+curl -fL -# "$script_url" -o "$script_tmp"
+curl -fL -# "$plist_url" -o "$plist_tmp"
+
+sudo install -d -o root -g wheel -m 755 "$(dirname "$bin_path")"
+sudo install -o root -g wheel -m 755 "$script_tmp" "$bin_path"
+sudo install -o root -g wheel -m 644 "$plist_tmp" "$plist_path"
+
+"$bin_path"

--- a/tests/install-security.test.sh
+++ b/tests/install-security.test.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+installer="$repo_root/install.sh"
+
+if ! grep -Eq 'bin_path="/usr/local/bin/sudo-touchid"' "$installer"; then
+  echo "install.sh must keep the sudo-touchid executable path explicit" >&2
+  exit 1
+fi
+
+if ! grep -Eq 'plist_path="/Library/LaunchDaemons/com.user.sudo-touchid.plist"' "$installer"; then
+  echo "install.sh must keep the LaunchDaemon plist path explicit" >&2
+  exit 1
+fi
+
+if ! grep -Eq 'sudo[[:space:]]+install[[:space:]].*-o[[:space:]]+root[[:space:]].*-g[[:space:]]+wheel[[:space:]].*-m[[:space:]]+755[[:space:]].*"\$bin_path"' "$installer"; then
+  echo "install.sh must install /usr/local/bin/sudo-touchid as root:wheel mode 755" >&2
+  exit 1
+fi
+
+if ! grep -Eq 'sudo[[:space:]]+install[[:space:]].*-o[[:space:]]+root[[:space:]].*-g[[:space:]]+wheel[[:space:]].*-m[[:space:]]+644[[:space:]].*"\$plist_path"' "$installer"; then
+  echo "install.sh must install the LaunchDaemon plist as root:wheel mode 644" >&2
+  exit 1
+fi
+
+if grep -Eq 'curl.*-o[[:space:]]+/usr/local/bin/sudo-touchid|chmod[[:space:]]+\+x[[:space:]]+/usr/local/bin/sudo-touchid' "$installer"; then
+  echo "install.sh must not write the daemon target directly as the invoking user" >&2
+  exit 1
+fi


### PR DESCRIPTION
This hardens the direct install script by avoiding user-owned writes to the LaunchDaemon target path.

Previously, install.sh downloaded sudo-touchid directly to /usr/local/bin/sudo-touchid and then applied chmod +x. The script now downloads to temporary files first, then installs:

- /usr/local/bin/sudo-touchid as root:wheel with mode 755
- /Library/LaunchDaemons/com.user.sudo-touchid.plist as root:wheel with mode 644

This also adds a small regression check for those installer invariants.